### PR TITLE
[remove-logs-from-ping-endpoint] Excludes ping endpoint from nginx logs.

### DIFF
--- a/docker/app/rootfs/etc/nginx/conf.d/default.conf
+++ b/docker/app/rootfs/etc/nginx/conf.d/default.conf
@@ -6,6 +6,18 @@ server {
     root /var/www/public;
     index index.php index.html;
 
+    location = /ping {
+        access_log off;
+        log_not_found off;
+
+        try_files $uri /index.php =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass unix:/var/run/php-fpm.sock;
+        fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        include fastcgi_params;
+    }
+
     location / {
         # remove trailing slash
         rewrite ^/(.*)/$ /$1 permanent;


### PR DESCRIPTION
Excludes /ping endpoint from nginx logs.