### PR TITLE
[run-nginx-as-nginx-user] run nginx as the nginx user

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -26,7 +26,6 @@ RUN addgroup -g 1000 -S www-data && \
   adduser -u 1000 -D -S -G www-data www-data
 
 RUN apk add --update $DEPS && \
-  chown www-data:www-data /var/tmp/nginx && \
   rm -rf /var/cache/apk/*
 
 # Set Timezone to UTC and remove apk cache

--- a/docker/app/rootfs/etc/nginx/nginx.conf
+++ b/docker/app/rootfs/etc/nginx/nginx.conf
@@ -1,5 +1,4 @@
 daemon off;
-user www-data;
 worker_processes auto;
 pid /run/nginx.pid;
 include /etc/nginx/modules-enabled/*.conf;


### PR DESCRIPTION
The default user for nginx on alpine linux is "nginx" not www-data. Changing the user to "www-data" caused permission issues, which is why we added the chown on the tmp folder.