### PR TITLE
[remove-build-image] remove the build dir

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,1 +1,0 @@
-FROM joblocal/base-build:alpine-3.7


### PR DESCRIPTION
We do not need the build image in the micro service template, since we use the base build image in the pipeline scripts.