### PR TITLE
upgrading base image and composer-git-hooks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   },
   "require-dev": {
     "barryvdh/laravel-ide-helper": "^2.8",
-    "brainmaestro/composer-git-hooks": "dev-prepare-for-symfony-6",
+    "brainmaestro/composer-git-hooks": "dev-master",
     "fakerphp/faker": "^1.9.1",
     "laravel/pint": "^1.2",
     "mockery/mockery": "^1.4.4",
@@ -34,14 +34,11 @@
   "config": {
     "optimize-autoloader": true,
     "preferred-install": "dist",
-    "sort-packages": true
-  },
-  "repositories": [
-    {
-      "type": "git",
-      "url": "https://github.com/Jubeki/composer-git-hooks"
+    "sort-packages": true,
+    "allow-plugins": {
+      "php-http/discovery": true
     }
-  ],
+  },
   "extra": {
     "laravel": {
       "dont-discover": []

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,3 +1,3 @@
-FROM joblocal/base-app:alpine-3.13
+FROM joblocal/base-app:alpine-3.16
 
 WORKDIR /var/www

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,1 +1,1 @@
-FROM joblocal/base-build:alpine-3.13
+FROM joblocal/base-build:alpine-3.16

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -1,3 +1,3 @@
-FROM joblocal/base-worker:alpine-3.13
+FROM joblocal/base-worker:alpine-3.16
 
 WORKDIR /var/www


### PR DESCRIPTION
Setting up the project as is currently isn't possible and required the following modifications:
  - upgrading base image version to 3.16 (now using PHP 8.1)
  - switching composer-git-hooks to the original master and removing the fork because it got merged